### PR TITLE
Best practice of encrypting the serialized token cache

### DIFF
--- a/active-directory-b2c-wpf/TokenCacheHelper.cs
+++ b/active-directory-b2c-wpf/TokenCacheHelper.cs
@@ -54,7 +54,7 @@ namespace active_directory_b2c_wpf
         /// <summary>
         /// Path to the token cache
         /// </summary>
-        public static string CacheFilePath = System.Reflection.Assembly.GetExecutingAssembly().Location + "msalcache.txt";
+        public static readonly string CacheFilePath = System.Reflection.Assembly.GetExecutingAssembly().Location + ".msalcache.bin";
 
         private static readonly object FileLock = new object();
 
@@ -63,7 +63,9 @@ namespace active_directory_b2c_wpf
             lock (FileLock)
             {
                 args.TokenCache.Deserialize(File.Exists(CacheFilePath)
-                    ? File.ReadAllBytes(CacheFilePath)
+                    ? ProtectedData.Unprotect(File.ReadAllBytes(CacheFilePath),
+                                              null,
+                                              DataProtectionScope.CurrentUser)
                     : null);
             }
         }
@@ -76,7 +78,11 @@ namespace active_directory_b2c_wpf
                 lock (FileLock)
                 {
                     // reflect changesgs in the persistent store
-                    File.WriteAllBytes(CacheFilePath, args.TokenCache.Serialize());
+                    File.WriteAllBytes(CacheFilePath,
+                                       ProtectedData.Protect(args.TokenCache.Serialize(), 
+                                                             null, 
+                                                             DataProtectionScope.CurrentUser)
+                                      );
                     // once the write operationtakes place restore the HasStateChanged bit to filse
                     args.TokenCache.HasStateChanged = false;
                 }

--- a/active-directory-b2c-wpf/active-directory-b2c-wpf.csproj
+++ b/active-directory-b2c-wpf/active-directory-b2c-wpf.csproj
@@ -39,6 +39,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Security" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Proposes a change to encrypt the MSAL.NET token cache on disk (best practice)