### PR TITLE
Update to msalv2.0.1

### DIFF
--- a/active-directory-b2c-wpf/App.xaml.cs
+++ b/active-directory-b2c-wpf/App.xaml.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 using Microsoft.Identity.Client;
 
 namespace active_directory_b2c_wpf
@@ -28,8 +22,6 @@ namespace active_directory_b2c_wpf
         public static string AuthorityEditProfile = BaseAuthority.Replace("{tenant}", Tenant).Replace("{policy}", PolicyEditProfile);
         public static string AuthorityResetPassword = BaseAuthority.Replace("{tenant}", Tenant).Replace("{policy}", PolicyResetPassword);
 
-        private static PublicClientApplication _clientApp = new PublicClientApplication(ClientId, Authority, TokenCacheHelper.GetUserCache());
-        
-        public static PublicClientApplication PublicClientApp { get { return _clientApp; } }
+        public static PublicClientApplication PublicClientApp { get; } = new PublicClientApplication(ClientId, Authority, TokenCacheHelper.GetUserCache());
     }
 }

--- a/active-directory-b2c-wpf/active-directory-b2c-wpf.csproj
+++ b/active-directory-b2c-wpf/active-directory-b2c-wpf.csproj
@@ -34,12 +34,15 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Identity.Client, Version=1.1.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.1.1.0-preview\lib\net45\Microsoft.Identity.Client.dll</HintPath>
+    <Reference Include="Microsoft.Identity.Client, Version=2.0.1.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.2.0.1-preview\lib\net45\Microsoft.Identity.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.IdentityModel" />
     <Reference Include="System.Security" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
@@ -90,7 +93,9 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/active-directory-b2c-wpf/packages.config
+++ b/active-directory-b2c-wpf/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Identity.Client" version="1.1.0-preview" targetFramework="net452" />
+  <package id="Microsoft.Identity.Client" version="2.0.1-preview" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Tested w/FB, Twitter, and Microsoft accounts (Google mult-auth was not redirecting back).
Can confirm that accounts are now deleted in relation to this [MSAL issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/613) and the `MsalUiRequiredException` is being thrown on the silent calls.