### PR TITLE
[DO NOT MERGE] Update to MSAL 3.x

### DIFF
--- a/active-directory-b2c-wpf/App.xaml.cs
+++ b/active-directory-b2c-wpf/App.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.AppConfig;
 
 namespace active_directory_b2c_wpf
 {
@@ -22,6 +23,15 @@ namespace active_directory_b2c_wpf
         public static string AuthorityEditProfile = BaseAuthority.Replace("{tenant}", Tenant).Replace("{policy}", PolicyEditProfile);
         public static string AuthorityResetPassword = BaseAuthority.Replace("{tenant}", Tenant).Replace("{policy}", PolicyResetPassword);
 
-        public static PublicClientApplication PublicClientApp { get; } = new PublicClientApplication(ClientId, Authority, TokenCacheHelper.GetUserCache());
+        public static IPublicClientApplication PublicClientApp { get; private set; }
+
+        static App()
+        {
+            PublicClientApp = PublicClientApplicationBuilder.Create(ClientId)
+                .WithB2CAuthority(Authority)
+                .Build();
+
+            TokenCacheHelper.Bind(PublicClientApp.UserTokenCache);
+        }
     }
 }

--- a/active-directory-b2c-wpf/MainWindow.xaml.cs
+++ b/active-directory-b2c-wpf/MainWindow.xaml.cs
@@ -30,7 +30,7 @@ namespace active_directory_b2c_wpf
             try
             {
                 authResult = await (app as PublicClientApplication).AcquireTokenInteractive(App.ApiScopes, null)
-                    .WithAccount(GetUserByPolicy(accounts, App.PolicySignUpSignIn))
+                    .WithAccount(GetAccountByPolicy(accounts, App.PolicySignUpSignIn))
                     .WithPrompt(Prompt.SelectAccount)
                     .ExecuteAsync(new System.Threading.CancellationToken());
 
@@ -44,7 +44,7 @@ namespace active_directory_b2c_wpf
                     if (ex.Message.Contains("AADB2C90118"))
                     {
                         authResult = await (app as PublicClientApplication).AcquireTokenInteractive(App.ApiScopes, null)
-                            .WithAccount(GetUserByPolicy(accounts, App.PolicySignUpSignIn))
+                            .WithAccount(GetAccountByPolicy(accounts, App.PolicySignUpSignIn))
                             .WithPrompt(Prompt.SelectAccount)
                             .WithB2CAuthority(App.AuthorityResetPassword)
                             .ExecuteAsync(new System.Threading.CancellationToken());
@@ -72,7 +72,7 @@ namespace active_directory_b2c_wpf
             {
                 ResultText.Text = $"Calling API:{App.AuthorityEditProfile}";
                 AuthenticationResult authResult = await (app as PublicClientApplication).AcquireTokenInteractive(App.ApiScopes, null)
-                            .WithAccount(GetUserByPolicy(accounts, App.PolicySignUpSignIn))
+                            .WithAccount(GetAccountByPolicy(accounts, App.PolicySignUpSignIn))
                             .WithPrompt(Prompt.NoPrompt)
                             .WithB2CAuthority(App.AuthorityEditProfile)
                             .ExecuteAsync(new System.Threading.CancellationToken());
@@ -93,7 +93,7 @@ namespace active_directory_b2c_wpf
             try
             {
                 authResult =  await (app as PublicClientApplication).AcquireTokenSilent(App.ApiScopes, null)
-                    .WithAccount(GetUserByPolicy(accounts, App.PolicySignUpSignIn))
+                    .WithAccount(GetAccountByPolicy(accounts, App.PolicySignUpSignIn))
                     .WithForceRefresh(false)
                     .ExecuteAsync(new System.Threading.CancellationToken());
             }
@@ -105,7 +105,7 @@ namespace active_directory_b2c_wpf
                 try
                 {
                      authResult = await (app as PublicClientApplication).AcquireTokenInteractive(App.ApiScopes, null)
-                    .WithAccount(GetUserByPolicy(accounts, App.PolicySignUpSignIn))
+                    .WithAccount(GetAccountByPolicy(accounts, App.PolicySignUpSignIn))
                     .ExecuteAsync(new System.Threading.CancellationToken());
                 }
                 catch (MsalException msalex)
@@ -213,7 +213,7 @@ namespace active_directory_b2c_wpf
                 IEnumerable<IAccount> accounts = await App.PublicClientApp.GetAccountsAsync();
 
                 AuthenticationResult authResult =  await (app as PublicClientApplication).AcquireTokenSilent(App.ApiScopes, null)
-                    .WithAccount(GetUserByPolicy(accounts, App.PolicySignUpSignIn))
+                    .WithAccount(GetAccountByPolicy(accounts, App.PolicySignUpSignIn))
                     .WithForceRefresh(true)
                     .ExecuteAsync(new System.Threading.CancellationToken());
 
@@ -234,7 +234,7 @@ namespace active_directory_b2c_wpf
             }
         }
 
-        private IAccount GetUserByPolicy(IEnumerable<IAccount> accounts, string policy)
+        private IAccount GetAccountByPolicy(IEnumerable<IAccount> accounts, string policy)
         {
             foreach (var account in accounts)
             {

--- a/active-directory-b2c-wpf/MainWindow.xaml.cs
+++ b/active-directory-b2c-wpf/MainWindow.xaml.cs
@@ -7,7 +7,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using System.Windows;
-using Microsoft.Identity.Client.ApiConfig;
+using System.Windows.Interop;
 
 namespace active_directory_b2c_wpf
 {

--- a/active-directory-b2c-wpf/TokenCacheHelper.cs
+++ b/active-directory-b2c-wpf/TokenCacheHelper.cs
@@ -33,7 +33,7 @@ namespace active_directory_b2c_wpf
 {
     static class TokenCacheHelper
     {
- 
+
         /// <summary>
         /// Get the user token cache
         /// </summary>
@@ -73,20 +73,23 @@ namespace active_directory_b2c_wpf
         public static void AfterAccessNotification(TokenCacheNotificationArgs args)
         {
             // if the access operation resulted in a cache update
-            if (args.TokenCache.HasStateChanged)
+            if (args.HasStateChanged)
             {
                 lock (FileLock)
                 {
                     // reflect changesgs in the persistent store
                     File.WriteAllBytes(CacheFilePath,
-                                       ProtectedData.Protect(args.TokenCache.Serialize(), 
-                                                             null, 
-                                                             DataProtectionScope.CurrentUser)
-                                      );
-                    // once the write operationtakes place restore the HasStateChanged bit to filse
-                    args.TokenCache.HasStateChanged = false;
+                                       ProtectedData.Protect(args.TokenCache.Serialize(),
+                                                             null,
+                                                             DataProtectionScope.CurrentUser));
                 }
             }
+        }
+
+        internal static void Bind(ITokenCache tokenCache)
+        {
+            tokenCache.SetBeforeAccess(BeforeAccessNotification);
+            tokenCache.SetAfterAccess(AfterAccessNotification);
         }
     }
 }

--- a/active-directory-b2c-wpf/active-directory-b2c-wpf.csproj
+++ b/active-directory-b2c-wpf/active-directory-b2c-wpf.csproj
@@ -34,8 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Identity.Client, Version=2.2.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.2.2.0-preview\lib\net45\Microsoft.Identity.Client.dll</HintPath>
+    <Reference Include="Microsoft.Identity.Client, Version=2.4.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.2.4.0-preview\lib\net45\Microsoft.Identity.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/active-directory-b2c-wpf/active-directory-b2c-wpf.csproj
+++ b/active-directory-b2c-wpf/active-directory-b2c-wpf.csproj
@@ -34,9 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Identity.Client, Version=2.6.2.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae">
-      <HintPath>..\packages\Microsoft.Identity.Client.2.6.2\lib\net45\Microsoft.Identity.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Identity.Client, Version=3.0.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.3.0.0-internal02303dev3x\lib\net45\Microsoft.Identity.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -94,9 +93,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/active-directory-b2c-wpf/packages.config
+++ b/active-directory-b2c-wpf/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Identity.Client" version="2.2.0-preview" allowedVersions="[2,3)" targetFramework="net452" />
+  <package id="Microsoft.Identity.Client" version="2.4.0-preview" allowedVersions="[2,3)" targetFramework="net452" />
 </packages>

--- a/active-directory-b2c-wpf/packages.config
+++ b/active-directory-b2c-wpf/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Identity.Client" version="2.6.2" allowedVersions="[2.4,3)" targetFramework="net452" />
+  <package id="Microsoft.Identity.Client" version="3.0.0-internal02303dev3x" allowedVersions="[2.4,3)" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
## Purpose
Update the sample to use MSAL 3.x new API 
Verified the sample works with the previous code with some minor changes:
> UIBehavior to Prompt
> `ITokenCache` does not contain a definition for `HasStateChanged`

This branch uses the new public API. When merged, this sample will only work w/MSALv3.x

Tested w/Facebook and Microsoft accounts