### PR TITLE
Changing redirect URI to https://login.microsoftonline.com/common/oau…

### DIFF
--- a/active-directory-b2c-wpf/App.xaml.cs
+++ b/active-directory-b2c-wpf/App.xaml.cs
@@ -28,6 +28,7 @@ namespace active_directory_b2c_wpf
         {
             PublicClientApp = PublicClientApplicationBuilder.Create(ClientId)
                 .WithB2CAuthority(Authority)
+                .WithDefaultRedirectUri()
                 .Build();
 
             TokenCacheHelper.Bind(PublicClientApp.UserTokenCache);


### PR DESCRIPTION
Changing redirect URI to https://login.microsoftonline.com/common/oauth2/nativeclient Via the new WithDefaultRedirectUri() method.

@jmprieur client ID "841e1190-d73a-450c-9d68-f5cf16b78e81" needs to be updated to use the new native client redirect URI