### PR TITLE
Design improvement to discuss for WithAuthority

### DIFF
--- a/active-directory-b2c-wpf/App.xaml.cs
+++ b/active-directory-b2c-wpf/App.xaml.cs
@@ -5,13 +5,6 @@ using Microsoft.Identity.Client;
 
 namespace active_directory_b2c_wpf
 {
-    public static class Extension
-    {
-        public static AbstractApplicationBuilder<PublicClientApplicationBuilder> WithAuthority(this AbstractApplicationBuilder<PublicClientApplicationBuilder> b, string authority, string policy)
-        {
-            return b.WithB2CAuthority(authority+"/"+policy);
-        }
-    }
 
     /// <summary>
     /// Interaction logic for App.xaml
@@ -27,7 +20,7 @@ namespace active_directory_b2c_wpf
 
         public static string[] ApiScopes = { "https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read" };
         public static string ApiEndpoint = "https://fabrikamb2chello.azurewebsites.net/hello";
-        private static string AuthorityBase = $"https://{AzureAdB2CHostname}/tfp/{Tenant}/";
+        public static string AuthorityBase = $"https://{AzureAdB2CHostname}/tfp/{Tenant}/";
         public static string AuthoritySignInSignUp = $"{AuthorityBase}{PolicySignUpSignIn}";
         public static string AuthorityEditProfile = $"{AuthorityBase}{PolicyEditProfile}";
         public static string AuthorityResetPassword = $"{AuthorityBase}{PolicyResetPassword}";
@@ -40,8 +33,8 @@ namespace active_directory_b2c_wpf
                 .WithB2CAuthority(AuthoritySignInSignUp)
                 // OR
                 .WithAuthority(AuthorityBase, PolicySignUpSignIn)
-                // Or
-                .WithAuthority("https://customdomain.com/"+PolicySignUpSignIn, validateAuthority:false)
+                // Or (ruled out)
+                // .WithAuthority("https://customdomain.com/"+PolicySignUpSignIn, validateAuthority:false)
                 .Build();
 
             TokenCacheHelper.Bind(PublicClientApp.UserTokenCache);

--- a/active-directory-b2c-wpf/Experimental-extension.cs
+++ b/active-directory-b2c-wpf/Experimental-extension.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Client
+{
+    public static class TrustedFrameworkPolicyAppBuilderExtension
+    {
+        /// <summary>
+        /// WithAuthority override enabling Trusted framework policies (for instance for Azure AD B2C)
+        /// when building an application
+        /// </summary>
+        /// <param name="builder">Application builder on which to apply the WithAuthority override</param>
+        /// <param name="baseAuthority">Base authority. This is the concatenation of authority host URL, and tenant</param>
+        /// <param name="trustedFrameworkPolicy">Policy</param>
+        /// <returns>The builder to be chained</returns>
+        public static T WithAuthority<T>(this T builder,
+                                      string baseAuthority,
+                                      string trustedFrameworkPolicy) where T : AbstractApplicationBuilder<T>
+        {
+            if (string.IsNullOrWhiteSpace(baseAuthority))
+            {
+                throw new ArgumentException($"{nameof(baseAuthority)} should not be null or only spaces", nameof(baseAuthority));
+            }
+            if (string.IsNullOrWhiteSpace(trustedFrameworkPolicy))
+            {
+                throw new ArgumentException($"{nameof(trustedFrameworkPolicy)} should not be null or only spaces", nameof(trustedFrameworkPolicy));
+            }
+
+            string b2cAuthority = baseAuthority.EndsWith("/") ? baseAuthority + trustedFrameworkPolicy
+                                                              : $"{baseAuthority}/{trustedFrameworkPolicy}";
+            return builder.WithB2CAuthority(b2cAuthority);
+        }
+    }
+
+    public static class TrustedFrameworkPolicyAcquireTokenBuilderExtension
+    {
+        /// <summary>
+        /// WithAuthority override enabling Trusted framework policies (for instance for Azure AD B2C)
+        /// when acquiring a token
+        /// </summary>
+        /// <param name="builder">Application builder on which to apply the WithAuthority override</param>
+        /// <param name="baseAuthority">Base authority. This is the concatenation of authority host URL, and tenant</param>
+        /// <param name="trustedFrameworkPolicy">Policy</param>
+        /// <returns>The builder to be chained</returns>
+        /// <returns></returns>
+        public static T WithAuthority<T>(this T builder,
+                      string baseAuthority,
+                      string trustedFrameworkPolicy) where T : AbstractAcquireTokenParameterBuilder<T>
+        {
+            if (string.IsNullOrWhiteSpace(baseAuthority))
+            {
+                throw new ArgumentException($"{nameof(baseAuthority)} should not be null or only spaces", nameof(baseAuthority));
+            }
+            if (string.IsNullOrWhiteSpace(trustedFrameworkPolicy))
+            {
+                throw new ArgumentException($"{nameof(trustedFrameworkPolicy)} should not be null or only spaces", nameof(trustedFrameworkPolicy));
+            }
+
+            string b2cAuthority = baseAuthority.EndsWith("/") ? baseAuthority + trustedFrameworkPolicy
+                                                              : $"{baseAuthority}/{trustedFrameworkPolicy}";
+            return builder.WithB2CAuthority(b2cAuthority);
+        }
+    }
+
+    public static class TrustedFrameworkPolicyAppExtension
+    {
+        /// <summary>
+        /// Get the accounts in the cache which fullfil a given trusted framework policy
+        /// </summary>
+        /// <param name="app">MSAL Application</param>
+        /// <param name="trustedFrameworkPolicy">Policy for which to filter the accounts</param>
+        /// <returns>Accounts for the given policy</returns>
+        public static async Task<IEnumerable<IAccount>> GetAccountsAsync(this IClientApplicationBase app, string trustedFrameworkPolicy)
+        {
+            if (string.IsNullOrWhiteSpace(trustedFrameworkPolicy))
+            {
+                throw new ArgumentException($"{nameof(trustedFrameworkPolicy)} should not be null or only spaces", nameof(trustedFrameworkPolicy));
+            }
+
+            string lowerCasePolicy = trustedFrameworkPolicy.ToLower();
+            IEnumerable<IAccount> accounts = await app.GetAccountsAsync();
+            return accounts.Where(account => account.HomeAccountId
+                                                    .ObjectId
+                                                    .Split('.')[0]
+                                                    .EndsWith(lowerCasePolicy));
+        }
+    }
+}

--- a/active-directory-b2c-wpf/active-directory-b2c-wpf.csproj
+++ b/active-directory-b2c-wpf/active-directory-b2c-wpf.csproj
@@ -64,6 +64,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Experimental-extension.cs" />
     <Compile Include="TokenCacheHelper.cs" />
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>


### PR DESCRIPTION
Improved the design of WithAuthority for B2C by:
- moving the extension class/method to a separate file
- Adding an extension method both for the App creation and token acquisition.

Not related, also proposed a different approach for GetAccountsForPolicy. This which should not be part of the current API Review, but from another one to come (like next week :).
I hesitated into bringing it here, but this appeared so clearly that I thought we'd want to discuss it.

This way the sample for B2C is almost exactly the same as for AAD, but we just inject policies where needed.