### PR TITLE
Update to .NET FW 4.7.2 to solve the TLS issue (with 4.2, there was a…

### DIFF
--- a/active-directory-b2c-wpf/App.config
+++ b/active-directory-b2c-wpf/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/active-directory-b2c-wpf/MainWindow.xaml.cs
+++ b/active-directory-b2c-wpf/MainWindow.xaml.cs
@@ -201,7 +201,7 @@ namespace active_directory_b2c_wpf
                 DisplayUserInfo(authResult);
                 UpdateSignInState(true);
             }
-            catch (MsalUiRequiredException ex)
+            catch (MsalUiRequiredException)
             {
                 // Ignore, user will need to sign in interactively.
                 ResultText.Text = "You need to sign-in first, and then Call API";

--- a/active-directory-b2c-wpf/Properties/Resources.Designer.cs
+++ b/active-directory-b2c-wpf/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace active_directory_b2c_wpf.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/active-directory-b2c-wpf/Properties/Settings.Designer.cs
+++ b/active-directory-b2c-wpf/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace active_directory_b2c_wpf.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.3.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/active-directory-b2c-wpf/TokenCacheHelper.cs
+++ b/active-directory-b2c-wpf/TokenCacheHelper.cs
@@ -27,30 +27,13 @@
 
 using System.IO;
 using System.Security.Cryptography;
+using System.Windows.Controls;
 using Microsoft.Identity.Client;
 
 namespace active_directory_b2c_wpf
 {
     static class TokenCacheHelper
     {
-
-        /// <summary>
-        /// Get the user token cache
-        /// </summary>
-        /// <returns></returns>
-        public static TokenCache GetUserCache()
-        {
-            if (usertokenCache == null)
-            {
-                usertokenCache = new TokenCache();
-                usertokenCache.SetBeforeAccess(BeforeAccessNotification);
-                usertokenCache.SetAfterAccess(AfterAccessNotification);
-            }
-            return usertokenCache;
-        }
-
-        static TokenCache usertokenCache;
-
         /// <summary>
         /// Path to the token cache
         /// </summary>

--- a/active-directory-b2c-wpf/active-directory-b2c-wpf.csproj
+++ b/active-directory-b2c-wpf/active-directory-b2c-wpf.csproj
@@ -8,11 +8,12 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>active_directory_b2c_wpf</RootNamespace>
     <AssemblyName>active_directory_b2c_wpf</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Update to .NET FW 4.7.2 to solve the TLS issue (with 4.2, there was a…n exception when calling the web api:

Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host.

Also removes removes warnings, including the obsolete cache constructor